### PR TITLE
UIORGS-48 remove falsy error notification (stripes-connect bug)

### DIFF
--- a/src/common/resources/contacts.js
+++ b/src/common/resources/contacts.js
@@ -1,6 +1,7 @@
 import { CONTACTS_API } from '../constants';
 
 export const contactResource = {
+  throwErrors: false,
   type: 'okapi',
   path: (queryParams, pathComponents) => {
     if (pathComponents.id) return `${CONTACTS_API}/${pathComponents.id}`;
@@ -9,7 +10,14 @@ export const contactResource = {
 };
 
 export const baseContactsResource = {
+  throwErrors: false,
   type: 'okapi',
   records: 'contacts',
   path: CONTACTS_API,
+};
+
+export const contactDetailsResource = {
+  throwErrors: false,
+  type: 'okapi',
+  path: `${CONTACTS_API}/:{id}`,
 };

--- a/src/contacts/ViewContact/ViewContactContainer.js
+++ b/src/contacts/ViewContact/ViewContactContainer.js
@@ -10,7 +10,7 @@ import {
 
 import {
   categoriesResource,
-  contactResource,
+  contactDetailsResource,
   organizationResource,
 } from '../../common/resources';
 import ViewContact from './ViewContact';
@@ -32,7 +32,7 @@ class ViewContactContainer extends Component {
   };
 
   static manifest = Object.freeze({
-    contact: contactResource,
+    contact: contactDetailsResource,
     categories: categoriesResource,
     organization: organizationResource,
   });
@@ -63,19 +63,18 @@ class ViewContactContainer extends Component {
     this.hideConfirmUnassign();
     unassign(mutator.organization, contactId, org)
       .then(() => showMessage('ui-organizations.contacts.message.unassigned.success'))
+      .then(() => this.onClose())
       .catch(() => showMessage('ui-organizations.contacts.message.unassigned.fail', 'error'));
   }
 
   onDeleteContact = () => {
-    const { match, mutator, resources, showMessage } = this.props;
+    const { match, mutator, resources } = this.props;
     const org = get(resources, 'organization.records.0');
     const contactId = get(match, 'params.id');
 
     this.hideConfirmDelete();
     deleteContact(mutator.organization, mutator.contact, contactId, org)
-      .then(() => showMessage('ui-organizations.contacts.message.deleted.success'))
-      .then(this.onClose)
-      .catch(() => showMessage('ui-organizations.contacts.message.deleted.fail', 'error'));
+      .finally(() => this.onClose());
   }
 
   render() {


### PR DESCRIPTION
## Purpose
There is a bug in stripes connect when (a couple, actually), so there is a false error notification when you wait promises on DELETE API call.
https://issues.folio.org/browse/UIORGS-48
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODGOBI-43
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
Basically, 1 error - to not use `path` as function - there is an exception on resource refresh in stripes-connect.
2nd - to not wait `then` after `mutator.DELETE()`, since stripes connect calls GET on that resource right after delete and gets 404 response, so returns an `.catch` case
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
