### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,9 +223,6 @@
     "react": "*",
     "react-router": "*"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "optionalDependencies": {
     "@folio/plugin-find-contact": "^1.1.0",
     "@folio/plugin-find-interface": "^1.0.0"


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.