### PR TITLE
FOLIO-3511 revert verify jenkins build with Node.js v16

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildNPM {
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java11'
   publishModDescriptor = true
   runLint = true
   runSonarqube = true


### PR DESCRIPTION
The verify Jenkins using Node 16 test was okay (#496).

So go back to Node 14 until the ui-organizations project is ready to upgrade. See https://dev.folio.org/guides/jenkinsfile/#front-end-modules and FOLIO-3434.
