### PR TITLE
UIORGS-382 Add a message indicating future functionality for EDI naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * *BREAKING* Upgrade React to v18. Refs UIORGS-377.
 * Upgrade `Node.js` to `18` version in GitHub Actions. Refs UIORGS-378.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIORGS-386.
+* Add a message indicating future functionality for EDI naming convention. Refs UIORGS-382.
 
 ## [4.0.0](https://github.com/folio-org/ui-organizations/tree/v4.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-organizations/compare/v3.3.1...v4.0.0)

--- a/src/OrganizationIntegration/OrganizationIntegrationForm/EdiForm/EdiForm.js
+++ b/src/OrganizationIntegration/OrganizationIntegrationForm/EdiForm/EdiForm.js
@@ -157,10 +157,15 @@ export const EdiForm = ({
               <>
                 <FormattedMessage id="ui-organizations.integration.edi.ediNamingConvention" />
                 <InfoPopover content={(
-                  <FormattedMessage
-                    id="ui-organizations.integration.edi.ediNamingConvention.info"
-                    values={{ tokens: Object.values(EDI_NAMING_TOKENS).join(', ') }}
-                  />)}
+                  <>
+                    <FormattedMessage id="ui-organizations.comingSoon" />
+                    <FormattedMessage
+                      id="ui-organizations.integration.edi.ediNamingConvention.info"
+                      values={{ tokens: <p>{Object.values(EDI_NAMING_TOKENS).join(', ')}</p> }}
+                      tagName="p"
+                    />
+                  </>
+                  )}
                 />
               </>
             )}

--- a/translations/ui-organizations/en.json
+++ b/translations/ui-organizations/en.json
@@ -10,6 +10,8 @@
   "notes.entity": "Organization",
   "notes.entityPlural": "Organizations",
 
+  "comingSoon": "Coming in a future release.",
+
   "data.contactTypes.address": "Address",
   "data.contactTypes.addressLine1": "Address 1",
   "data.contactTypes.addressLine2": "Address 2",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIORGS-382

In the Integration Details of an organization record, a user cannot change the EDI Naming Convention, but the information pop-up indicates this should work. The functionality should work after implementation of the [UIORGS-385](https://issues.folio.org/browse/UIORGS-385)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Display clear message for a user that the feature will be available only in the future realeses.

## Screenshots
![image](https://github.com/folio-org/ui-organizations/assets/88109087/ca8464b3-7a5d-4d2d-bea5-5e277cc1fecc)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
