### PR TITLE
[UXPROD-3903] Support data-export-spring interface 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Factor away from unsupported `color()` function. Refs UIORGS-416.
 * Suppress banking information management for unauthorized user. Refs UIORGS-418.
 * Add validation for `Day` field in `Monthly` scheduler for export method. Refs UIORGS-417.
+* Support `data-export-spring` interface `v2.0`. Refs UXPROD-3903.
 
 ## [5.0.0](https://github.com/folio-org/ui-organizations/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-organizations/compare/v4.0.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "okapiInterfaces": {
       "acquisition-methods": "1.0",
       "banking-information": "1.0",
-      "data-export-spring": "1.0",
+      "data-export-spring": "1.0 2.0",
       "configuration": "2.0",
       "organizations.organizations": "1.0",
       "organizations-storage.addresses": "1.1",


### PR DESCRIPTION
# [Jira UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903)

## Purpose
Work being done by @folio-org/bama in [mod-data-export-spring](https://github.com/folio-org/mod-data-export-spring/pull/270) and related modules necessitated a breaking change in the provided `data-export-spring` interface, bumping its version to `2.0`.  This breaking change has no impact on `ui-organizations`; as such, we can safely update our `package.json` to support this new version.

> [!WARNING]
> This PR **must** be merged before https://github.com/folio-org/mod-data-export-spring/pull/270, otherwise the snapshot environment will break.