### PR TITLE
UIORGS-424 Accurately handle user permissions for banking information operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Factor away from unsupported `color()` function. Refs UIORGS-416.
 * Suppress banking information management for unauthorized user. Refs UIORGS-418.
 * Add validation for `Day` field in `Monthly` scheduler for export method. Refs UIORGS-417.
+* Accurately handle user permissions for banking information operations. Refs UIORGS-424.
 
 ## [5.0.0](https://github.com/folio-org/ui-organizations/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-organizations/compare/v4.0.0...v5.0.0)

--- a/src/OrganizationIntegration/OrganizationIntegrationForm/__snapshots__/OrganizationIntegrationForm.test.js.snap
+++ b/src/OrganizationIntegration/OrganizationIntegrationForm/__snapshots__/OrganizationIntegrationForm.test.js.snap
@@ -147,7 +147,7 @@ exports[`OrganizationIntegrationForm should render correct form structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 4;"
+                  style="z-index: 0;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-integrationInfo"
@@ -330,7 +330,7 @@ exports[`OrganizationIntegrationForm should render correct form structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 3;"
+                  style="z-index: 1;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-edi"
@@ -1379,7 +1379,7 @@ exports[`OrganizationIntegrationForm should render correct form structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 1;"
+                  style="z-index: 3;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-scheduling"

--- a/src/OrganizationIntegration/OrganizationIntegrationView/__snapshots__/OrganizationIntegrationView.test.js.snap
+++ b/src/OrganizationIntegration/OrganizationIntegrationView/__snapshots__/OrganizationIntegrationView.test.js.snap
@@ -217,7 +217,7 @@ exports[`OrganizationIntegrationView should render correct view structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 4;"
+                  style="z-index: 0;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-integrationInfo"
@@ -369,7 +369,7 @@ exports[`OrganizationIntegrationView should render correct view structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 3;"
+                  style="z-index: 1;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-edi"
@@ -1061,7 +1061,7 @@ exports[`OrganizationIntegrationView should render correct view structure 1`] = 
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 1;"
+                  style="z-index: 3;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-scheduling"

--- a/src/Organizations/OrganizationForm/OrganizationVendorInfoForm/__snapshots__/OrganizationVendorInfoForm.test.js.snap
+++ b/src/Organizations/OrganizationForm/OrganizationVendorInfoForm/__snapshots__/OrganizationVendorInfoForm.test.js.snap
@@ -636,7 +636,7 @@ exports[`OrganizationVendorInfoForm should render correct structure 1`] = `
             </div>
             <div
               class="content-wrap expanded"
-              style="z-index: 1;"
+              style="z-index: 0;"
             >
               <div
                 aria-labelledby="accordion-toggle-button-taxSection"

--- a/src/Organizations/OrganizationForm/__snapshots__/OrganizationForm.test.js.snap
+++ b/src/Organizations/OrganizationForm/__snapshots__/OrganizationForm.test.js.snap
@@ -154,7 +154,7 @@ exports[`OrganizationForm should render correct form with metadata 1`] = `
                     </div>
                     <div
                       class="content-wrap expanded"
-                      style="z-index: 4;"
+                      style="z-index: 0;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-summarySection"
@@ -215,7 +215,7 @@ exports[`OrganizationForm should render correct form with metadata 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 3;"
+                      style="z-index: 1;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-contactInformationSection"
@@ -331,7 +331,7 @@ exports[`OrganizationForm should render correct form with metadata 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 1;"
+                      style="z-index: 3;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-interfacesSection"
@@ -566,7 +566,7 @@ exports[`OrganizationForm should render correct non-vendor form structure 1`] = 
                     </div>
                     <div
                       class="content-wrap expanded"
-                      style="z-index: 4;"
+                      style="z-index: 0;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-summarySection"
@@ -624,7 +624,7 @@ exports[`OrganizationForm should render correct non-vendor form structure 1`] = 
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 3;"
+                      style="z-index: 1;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-contactInformationSection"
@@ -740,7 +740,7 @@ exports[`OrganizationForm should render correct non-vendor form structure 1`] = 
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 1;"
+                      style="z-index: 3;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-interfacesSection"
@@ -975,7 +975,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap expanded"
-                      style="z-index: 7;"
+                      style="z-index: 0;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-summarySection"
@@ -1033,7 +1033,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 6;"
+                      style="z-index: 1;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-contactInformationSection"
@@ -1091,7 +1091,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 5;"
+                      style="z-index: 2;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-contactPeopleSection"
@@ -1149,7 +1149,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 4;"
+                      style="z-index: 3;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-interfacesSection"
@@ -1207,7 +1207,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 3;"
+                      style="z-index: 4;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-vendorInformationSection"
@@ -1265,7 +1265,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 2;"
+                      style="z-index: 5;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-agreementsSection"
@@ -1323,7 +1323,7 @@ exports[`OrganizationForm should render correct vendor form structure 1`] = `
                     </div>
                     <div
                       class="content-wrap"
-                      style="z-index: 1;"
+                      style="z-index: 6;"
                     >
                       <div
                         aria-labelledby="accordion-toggle-button-accountsSection"

--- a/src/contacts/EditContact/__snapshots__/EditContact.test.js.snap
+++ b/src/contacts/EditContact/__snapshots__/EditContact.test.js.snap
@@ -147,7 +147,7 @@ exports[`EditContact should render correct form structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 5;"
+                  style="z-index: 0;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-name"
@@ -7997,7 +7997,7 @@ exports[`EditContact should render correct form structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 4;"
+                  style="z-index: 1;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-emails"
@@ -15846,7 +15846,7 @@ exports[`EditContact should render correct form structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 3;"
+                  style="z-index: 2;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-phones"
@@ -23718,7 +23718,7 @@ exports[`EditContact should render correct form structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 2;"
+                  style="z-index: 3;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-urls"
@@ -31567,7 +31567,7 @@ exports[`EditContact should render correct form structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 1;"
+                  style="z-index: 5;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-addresses"

--- a/src/contacts/ViewContact/__snapshots__/ViewContact.test.js.snap
+++ b/src/contacts/ViewContact/__snapshots__/ViewContact.test.js.snap
@@ -227,7 +227,7 @@ exports[`ViewContact should render correct structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 5;"
+                  style="z-index: 0;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-name"
@@ -429,7 +429,7 @@ exports[`ViewContact should render correct structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 4;"
+                  style="z-index: 1;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-emails"
@@ -640,7 +640,7 @@ exports[`ViewContact should render correct structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 3;"
+                  style="z-index: 2;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-phones"
@@ -851,7 +851,7 @@ exports[`ViewContact should render correct structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 2;"
+                  style="z-index: 3;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-urls"
@@ -1069,7 +1069,7 @@ exports[`ViewContact should render correct structure 1`] = `
                 </div>
                 <div
                   class="content-wrap expanded"
-                  style="z-index: 1;"
+                  style="z-index: 4;"
                 >
                   <div
                     aria-labelledby="accordion-toggle-button-contact-addresses"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIORGS-424

Enable users with relevant permissions to carry out banking operations for the organization.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Banking information manager now checks all permissions simultaneously regardless of action type. Each CRUD operation should rely on its own permission.

## Screenshots
#### Edit

https://github.com/folio-org/ui-organizations/assets/88109087/b46b48ba-d7f8-4df5-b49f-2ed3682b82b7

#### Create

https://github.com/folio-org/ui-organizations/assets/88109087/9e91f9d9-d91f-4152-8969-5312b9593672

#### Delete


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
