### PR TITLE
UIORGS-425 Fixed UX Consistency Issue

### DIFF
--- a/src/OrganizationIntegration/OrganizationIntegrationForm/OrganizationIntegrationForm.js
+++ b/src/OrganizationIntegration/OrganizationIntegrationForm/OrganizationIntegrationForm.js
@@ -55,7 +55,7 @@ const OrganizationIntegrationForm = ({
           disabled={pristine || submitting}
           onClick={handleSubmit}
         >
-          <FormattedMessage id="ui-organizations.button.saveAndClose" />
+          <FormattedMessage id="stripes-components.saveAndClose" />
         </Button>
       );
 

--- a/src/Organizations/OrganizationForm/OrganizationForm.js
+++ b/src/Organizations/OrganizationForm/OrganizationForm.js
@@ -104,7 +104,7 @@ const OrganizationForm = ({
   const paneFooter = (
     <FormFooter
       id="organization-form-save"
-      label={<FormattedMessage id="ui-organizations.button.saveAndClose" />}
+      label={<FormattedMessage id="stripes-components.saveAndClose" />}
       pristine={pristine}
       submitting={submitting}
       handleSubmit={handleSubmit}

--- a/src/contacts/EditContact/EditContact.js
+++ b/src/contacts/EditContact/EditContact.js
@@ -85,7 +85,7 @@ const EditContact = ({
           disabled={pristine || submitting}
           onClick={handleSubmit}
         >
-          <FormattedMessage id="ui-organizations.button.saveAndClose" />
+          <FormattedMessage id="stripes-components.saveAndClose" />
         </Button>
       );
 

--- a/translations/ui-organizations/ar.json
+++ b/translations/ui-organizations/ar.json
@@ -283,7 +283,6 @@
     "showTags": "عرض الوسوم",
     "search.keyword": "الكل",
     "button.cancel": "إلغاء",
-    "button.saveAndClose": "حفظ وإغلاق",
     "interface.url": "عنوان URL",
     "interface.type": "النوع",
     "edit.hideCredentials": "إخفاء البيانات",

--- a/translations/ui-organizations/ber.json
+++ b/translations/ui-organizations/ber.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/ca.json
+++ b/translations/ui-organizations/ca.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/cs_CZ.json
+++ b/translations/ui-organizations/cs_CZ.json
@@ -283,7 +283,6 @@
     "showTags": "Zobrazit štítky",
     "search.keyword": "Všechny",
     "button.cancel": "Zrušit",
-    "button.saveAndClose": "Uložit a zavřít",
     "interface.url": "URL",
     "interface.type": "Typ",
     "edit.hideCredentials": "Skrýt přihlašovací údaje",

--- a/translations/ui-organizations/da.json
+++ b/translations/ui-organizations/da.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Gem & luk",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Skjul legitimationsoplysninger",

--- a/translations/ui-organizations/de.json
+++ b/translations/ui-organizations/de.json
@@ -283,7 +283,6 @@
     "showTags": "Tags anzeigen",
     "search.keyword": "Alles",
     "button.cancel": "Abbrechen",
-    "button.saveAndClose": "Speichern & schließen",
     "interface.url": "URL",
     "interface.type": "Typ",
     "edit.hideCredentials": "Anmeldeinformationen ausblenden",

--- a/translations/ui-organizations/en.json
+++ b/translations/ui-organizations/en.json
@@ -138,7 +138,6 @@
 
   "button.bankingInformation.add": "Add banking information",
   "button.cancel": "Cancel",
-  "button.saveAndClose": "Save & close",
 
   "contacts.actions.load.error": "Failed to load contacts data",
 

--- a/translations/ui-organizations/en_GB.json
+++ b/translations/ui-organizations/en_GB.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/en_SE.json
+++ b/translations/ui-organizations/en_SE.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/en_US.json
+++ b/translations/ui-organizations/en_US.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/es.json
+++ b/translations/ui-organizations/es.json
@@ -283,7 +283,6 @@
     "showTags": "Mostrar Etiquetas",
     "search.keyword": "Todo",
     "button.cancel": "Cancelar",
-    "button.saveAndClose": "Guardar y cerrar",
     "interface.url": "URL",
     "interface.type": "Tipo",
     "edit.hideCredentials": "Ocultar credenciales",

--- a/translations/ui-organizations/es_419.json
+++ b/translations/ui-organizations/es_419.json
@@ -283,7 +283,6 @@
     "showTags": "Mostrar Etiquetas",
     "search.keyword": "Todo",
     "button.cancel": "Cancelar",
-    "button.saveAndClose": "Guardar y cerrar",
     "interface.url": "URL",
     "interface.type": "Tipo",
     "edit.hideCredentials": "Ocultar credenciales",

--- a/translations/ui-organizations/es_ES.json
+++ b/translations/ui-organizations/es_ES.json
@@ -283,7 +283,6 @@
     "showTags": "Mostrar Etiquetas",
     "search.keyword": "Todo",
     "button.cancel": "Cancelar",
-    "button.saveAndClose": "Guardar y cerrar",
     "interface.url": "URL",
     "interface.type": "Tipo",
     "edit.hideCredentials": "Ocultar credenciales",

--- a/translations/ui-organizations/fr.json
+++ b/translations/ui-organizations/fr.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/fr_FR.json
+++ b/translations/ui-organizations/fr_FR.json
@@ -283,7 +283,6 @@
     "showTags": "Afficher les mots-clés",
     "search.keyword": "Tout",
     "button.cancel": "Annuler",
-    "button.saveAndClose": "Sauvegarder et fermer",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Masquer les informations d'identification",

--- a/translations/ui-organizations/he.json
+++ b/translations/ui-organizations/he.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/hi_IN.json
+++ b/translations/ui-organizations/hi_IN.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/hu.json
+++ b/translations/ui-organizations/hu.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/it_IT.json
+++ b/translations/ui-organizations/it_IT.json
@@ -283,7 +283,6 @@
     "showTags": "Mostra tag",
     "search.keyword": "Tutto",
     "button.cancel": "Annulla",
-    "button.saveAndClose": "Salva e chiudi",
     "interface.url": "URL",
     "interface.type": "Tipo",
     "edit.hideCredentials": "Nascondi credenziali",

--- a/translations/ui-organizations/ja.json
+++ b/translations/ui-organizations/ja.json
@@ -283,7 +283,6 @@
     "showTags": "タグを表示",
     "search.keyword": "全部",
     "button.cancel": "キャンセル",
-    "button.saveAndClose": "保存して閉じる",
     "interface.url": "URL",
     "interface.type": "種類",
     "edit.hideCredentials": "資格情報を非表示にする",

--- a/translations/ui-organizations/ko.json
+++ b/translations/ui-organizations/ko.json
@@ -283,7 +283,6 @@
     "showTags": "태그 표시",
     "search.keyword": "모두",
     "button.cancel": "취소",
-    "button.saveAndClose": "저장 후 닫기",
     "interface.url": "URL",
     "interface.type": "유형",
     "edit.hideCredentials": "인증정보 숨기기",

--- a/translations/ui-organizations/nb.json
+++ b/translations/ui-organizations/nb.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/nn.json
+++ b/translations/ui-organizations/nn.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/pl.json
+++ b/translations/ui-organizations/pl.json
@@ -283,7 +283,6 @@
     "showTags": "Pokaż etykiety",
     "search.keyword": "Wszystkie",
     "button.cancel": "Anuluj",
-    "button.saveAndClose": "Zapisz i zamknij",
     "interface.url": "URL",
     "interface.type": "Rodzaj",
     "edit.hideCredentials": "Ukryj dane uwierzytelniające",

--- a/translations/ui-organizations/pt_BR.json
+++ b/translations/ui-organizations/pt_BR.json
@@ -283,7 +283,6 @@
     "showTags": "Mostrar tags",
     "search.keyword": "Todos",
     "button.cancel": "Cancelar",
-    "button.saveAndClose": "Salvar e fechar",
     "interface.url": "URL",
     "interface.type": "Tipo",
     "edit.hideCredentials": "Ocultar credenciais",

--- a/translations/ui-organizations/pt_PT.json
+++ b/translations/ui-organizations/pt_PT.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/ru.json
+++ b/translations/ui-organizations/ru.json
@@ -283,7 +283,6 @@
     "showTags": "Показать теги",
     "search.keyword": "Все",
     "button.cancel": "Отмена",
-    "button.saveAndClose": "Сохранить и закрыть",
     "interface.url": "URL",
     "interface.type": "Тип",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/sk.json
+++ b/translations/ui-organizations/sk.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/sv.json
+++ b/translations/ui-organizations/sv.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/ur.json
+++ b/translations/ui-organizations/ur.json
@@ -283,7 +283,6 @@
     "showTags": "Show tags",
     "search.keyword": "All",
     "button.cancel": "Cancel",
-    "button.saveAndClose": "Save & close",
     "interface.url": "URL",
     "interface.type": "Type",
     "edit.hideCredentials": "Hide credentials",

--- a/translations/ui-organizations/zh_CN.json
+++ b/translations/ui-organizations/zh_CN.json
@@ -283,7 +283,6 @@
     "showTags": "显示标签",
     "search.keyword": "所有",
     "button.cancel": "取消",
-    "button.saveAndClose": "保存并关闭",
     "interface.url": "URL",
     "interface.type": "类型",
     "edit.hideCredentials": "隐藏凭证",

--- a/translations/ui-organizations/zh_TW.json
+++ b/translations/ui-organizations/zh_TW.json
@@ -283,7 +283,6 @@
     "showTags": "顯示標籤",
     "search.keyword": "全部",
     "button.cancel": "取消",
-    "button.saveAndClose": "儲存並關閉",
     "interface.url": "URL",
     "interface.type": "類型",
     "edit.hideCredentials": "隱藏憑證",


### PR DESCRIPTION
## Purpose
Implemented new translation keys for "Save & close" buttons in order to support UX consistency
[UIORGS-425](https://folio-org.atlassian.net/browse/UIORGS-425)

## Approach
Changed all translation keys from local translations (`'ui-organizations.button.saveAndClose'`) to stripes-components translations (`'stripes-components.saveAndClose'`)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
