### PR TITLE
UIORGS-466 upgrade @folio/stripes-acq-components to v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.0 (IN PROGRESS)
 
 * Change radio buttons into drop-down in Settings > Organizations > Number generator options. Refs UIORGS-462.
+* Upgrade `@folio/stripes-acq-components` to `v7.0.2`. Refs UIORGS-466.
 
 ## [6.0.0](https://github.com/folio-org/ui-organizations/tree/v6.0.0) (2025-03-12)
 [Full Changelog](https://github.com/folio-org/ui-organizations/compare/v5.2.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -373,7 +373,7 @@
   },
   "dependencies": {
     "@folio/plugin-find-organization": "^6.0.0",
-    "@folio/stripes-acq-components": "~7.0.0",
+    "@folio/stripes-acq-components": "~7.0.2",
     "lodash": "^4.17.5",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.20",


### PR DESCRIPTION
Upgrade `@folio/stripes-acq-components` to `~7.0.2` to guarantee that the fix for UISACQCOMP-258 is pulled in.

Refs [UIORGS-466](https://folio-org.atlassian.net/browse/UIORGS-466)
