### PR TITLE
UIORGS-478 Rename permissions to make it easier to differentiate between them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Memoize initial values for the integration form to prevent data from becoming stale. Refs UIORGS-472.
 * Include global `stripes-core.settings.read` permission in base permission sets. Refs UIORGS-476.
 * Replace the `moment` library with `dayjs` (Part 1). Refs UIORGS-463.
+* Rename permissions to make it easier to differentiate between them. Refs UIORGS-478.
 
 ## [6.0.1](https://github.com/folio-org/ui-organizations/tree/v6.0.1) (2025-05-05)
 [Full Changelog](https://github.com/folio-org/ui-organizations/compare/v6.0.0...v6.0.1)

--- a/package.json
+++ b/package.json
@@ -235,21 +235,27 @@
         ]
       },
       {
-        "permissionName": "ui-organizations.acqUnits.assign",
+        "permissionName": "ui-organizations.organizations.acquisitions_units.assign.execute",
         "displayName": "Organizations: Assign acquisition units to new organization",
         "description": "",
         "visible": true,
+        "replaces": [
+          "ui-organizations.acqUnits.assign"
+        ],
         "subPermissions": [
-          "organizations.acquisitions-units-assignments.assign"
+          "organizations.acquisitions-units-assignments.create.execute"
         ]
       },
       {
-        "permissionName": "ui-organizations.acqUnits.manage",
+        "permissionName": "ui-organizations.organizations.acquisitions_units.manage.execute",
         "displayName": "Organizations: Manage acquisition units",
         "description": "",
         "visible": true,
+        "replaces": [
+          "ui-organizations.acqUnits.manage"
+        ],
         "subPermissions": [
-          "organizations.acquisitions-units-assignments.manage"
+          "organizations.acquisitions-units-assignments.manage.execute"
         ]
       },
       {

--- a/src/Organizations/constants.js
+++ b/src/Organizations/constants.js
@@ -29,8 +29,8 @@ export const ORGANIZATION_SECTION_LABELS = {
   [ORGANIZATION_SECTIONS.privilegedDonorInformation]: <FormattedMessage id="ui-organizations.privilegedDonorInformation" />,
 };
 
-export const CREATE_UNITS_PERM = 'organizations.acquisitions-units-assignments.assign';
-export const MANAGE_UNITS_PERM = 'organizations.acquisitions-units-assignments.manage';
+export const CREATE_UNITS_PERM = 'organizations.acquisitions-units-assignments.create.execute';
+export const MANAGE_UNITS_PERM = 'organizations.acquisitions-units-assignments.manage.execute';
 
 // Mapping between attribute (field) in form and id of accordion
 export const MAP_FIELD_ACCORDION = {


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/UIORGS-478

There was determined that a few permissions are named very similarly. When resources/capabilities are created for these, it becomes difficult to differentiate between the two.